### PR TITLE
EPSS URL Update

### DIFF
--- a/loop.sh
+++ b/loop.sh
@@ -5,7 +5,7 @@ do
 
 ./update_cve5.sh
 
-wget https://epss.cyentia.com/epss_scores-current.csv.gz
+wget https://epss.empiricalsecurity.com/epss_scores-current.csv.gz
 gunzip -f epss_scores-current.csv.gz
 
 ./get-nvd-json.py && ./json-parse.py nvd-out.json


### PR DESCRIPTION
Update Loop.sh to the new EPSS URL at https://epss.empiricalsecurity.com/epss_scores-current.csv.gz,   https://epss.cyentia.com/epss_scores-current.csv.gz is now dead